### PR TITLE
rtmp2rtc: Support RTMP-to-WebRTC conversion with HEVC. v7.0.33 (#4289)

### DIFF
--- a/trunk/doc/CHANGELOG.md
+++ b/trunk/doc/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for SRS.
 <a name="v7-changes"></a>
 
 ## SRS 7.0 Changelog
+* v7.0, 2025-05-13, Merge [#4289](https://github.com/ossrs/srs/pull/4289): rtmp2rtc: Support RTMP-to-WebRTC conversion with HEVC. v7.0.33 (#4289)
 * v7.0, 2025-04-30, Merge [#4308](https://github.com/ossrs/srs/pull/4308): Fix memory leaks from errors skipping resource release. v7.0.32 (#4308)
 * v7.0, 2025-04-26, Merge [#4292](https://github.com/ossrs/srs/pull/4309): Support custom deleter for SrsUniquePtr. v7.0.31 (#4309)
 * v7.0, 2025-03-21, Merge [#4292](https://github.com/ossrs/srs/pull/4292): Typo: "forked" process in log output. v7.0.30 (#4292)

--- a/trunk/src/app/srs_app_hls.cpp
+++ b/trunk/src/app/srs_app_hls.cpp
@@ -1068,7 +1068,7 @@ srs_error_t SrsHlsController::write_video(SrsVideoFrame* frame, int64_t dts)
 
     // Refresh the codec ASAP.
     if (muxer->latest_vcodec() != frame->vcodec()->id) {
-        srs_trace("HLS: Switch video codec %d(%s) to %d(%s)", muxer->latest_acodec(), srs_video_codec_id2str(muxer->latest_vcodec()).c_str(),
+        srs_trace("HLS: Switch video codec %d(%s) to %d(%s)", muxer->latest_vcodec(), srs_video_codec_id2str(muxer->latest_vcodec()).c_str(),
                   frame->vcodec()->id, srs_video_codec_id2str(frame->vcodec()->id).c_str());
         muxer->set_latest_vcodec(frame->vcodec()->id);
     }

--- a/trunk/src/app/srs_app_rtc_sdp.cpp
+++ b/trunk/src/app/srs_app_rtc_sdp.cpp
@@ -92,6 +92,42 @@ srs_error_t srs_parse_h264_fmtp(const std::string& fmtp, H264SpecificParam& h264
     return err;
 }
 
+srs_error_t srs_parse_h265_fmtp(const std::string& fmtp, H265SpecificParam& h265_param)
+{
+    srs_error_t err = srs_success;
+
+    std::vector<std::string> vec = srs_string_split(fmtp, ";");
+    for (size_t i = 0; i < vec.size(); ++i) {
+        std::vector<std::string> kv = srs_string_split(vec[i], "=");
+        if (kv.size() != 2) continue;
+
+        if (kv[0] == "level-id") {
+            h265_param.level_id = kv[1];
+        } else if (kv[0] == "profile-id") {
+            h265_param.profile_id = kv[1];
+        } else if (kv[0] == "tier-flag") {
+            h265_param.tier_flag = kv[1];
+        } else if (kv[0] == "tx-mode") {
+            h265_param.tx_mode = kv[1];
+        }
+    }
+
+    if (h265_param.level_id.empty()) {
+        return srs_error_new(ERROR_RTC_SDP_DECODE, "no h265 param: level-id");
+    }
+    if (h265_param.profile_id.empty()) {
+        return srs_error_new(ERROR_RTC_SDP_DECODE, "no h265 param: profile-id");
+    }
+    if (h265_param.tier_flag.empty()) {
+        return srs_error_new(ERROR_RTC_SDP_DECODE, "no h265 param: tier-flag");
+    }
+    if (h265_param.tx_mode.empty()) {
+        return srs_error_new(ERROR_RTC_SDP_DECODE, "no h265 param: tx-mode");
+    }
+
+    return err; 
+}
+
 SrsSessionInfo::SrsSessionInfo()
 {
 }

--- a/trunk/src/app/srs_app_rtc_sdp.hpp
+++ b/trunk/src/app/srs_app_rtc_sdp.hpp
@@ -97,8 +97,16 @@ struct H264SpecificParam
     std::string level_asymmerty_allow;
 };
 
-extern srs_error_t srs_parse_h264_fmtp(const std::string& fmtp, H264SpecificParam& h264_param);
+struct H265SpecificParam
+{
+    std::string level_id;
+    std::string profile_id;
+    std::string tier_flag;
+    std::string tx_mode;
+};
 
+extern srs_error_t srs_parse_h264_fmtp(const std::string& fmtp, H264SpecificParam& h264_param);
+extern srs_error_t srs_parse_h265_fmtp(const std::string& fmtp, H265SpecificParam& h265_param);
 class SrsMediaPayloadType
 {
 public:

--- a/trunk/src/app/srs_app_rtc_source.hpp
+++ b/trunk/src/app/srs_app_rtc_source.hpp
@@ -396,6 +396,7 @@ class SrsVideoPayload : public SrsCodecPayload
 {
 public:
     H264SpecificParam h264_param_;
+    H265SpecificParam h265_param_;
 
 public:
     SrsVideoPayload();
@@ -404,8 +405,10 @@ public:
 public:
     virtual SrsVideoPayload* copy();
     virtual SrsMediaPayloadType generate_media_payload_type();
+    virtual SrsMediaPayloadType generate_media_payload_type_h265();
 public:
     srs_error_t set_h264_param_desc(std::string fmtp);
+    srs_error_t set_h265_param_desc(std::string fmtp);
 };
 
 // TODO: FIXME: Rename it.

--- a/trunk/src/app/srs_app_stream_bridge.hpp
+++ b/trunk/src/app/srs_app_stream_bridge.hpp
@@ -65,6 +65,8 @@ private:
 #if defined(SRS_FFMPEG_FIT)
     SrsRtcRtpBuilder* rtp_builder_;
 #endif
+private:
+    SrsVideoCodecId video_codec_id_;
 public:
     SrsFrameToRtcBridge(SrsSharedPtr<SrsRtcSource> source);
     virtual ~SrsFrameToRtcBridge();
@@ -74,6 +76,7 @@ public:
     virtual void on_unpublish();
     virtual srs_error_t on_frame(SrsSharedPtrMessage* frame);
     srs_error_t on_rtp(SrsRtpPacket* pkt);
+    srs_error_t update_codec(SrsVideoCodecId id);
 };
 #endif
 

--- a/trunk/src/core/srs_core_version7.hpp
+++ b/trunk/src/core/srs_core_version7.hpp
@@ -9,6 +9,6 @@
 
 #define VERSION_MAJOR       7
 #define VERSION_MINOR       0
-#define VERSION_REVISION    32
+#define VERSION_REVISION    33
 
 #endif

--- a/trunk/src/kernel/srs_kernel_codec.hpp
+++ b/trunk/src/kernel/srs_kernel_codec.hpp
@@ -14,6 +14,12 @@
 
 class SrsBuffer;
 class SrsBitBuffer;
+class SrsFormat;
+
+// @see: https://datatracker.ietf.org/doc/html/rfc6184#section-1.3  
+const int SrsAvcNaluHeaderSize = 1;
+// @see: https://datatracker.ietf.org/doc/html/rfc7798#section-1.1.4
+const int SrsHevcNaluHeaderSize = 2;
 
 /**
  * The video codec id.
@@ -421,6 +427,8 @@ enum SrsAvcNaluType
     // Coded slice extension slice_layer_extension_rbsp( )
     SrsAvcNaluTypeCodedSliceExt = 20,
 };
+// @see https://datatracker.ietf.org/doc/html/rfc6184#section-1.3
+#define SrsAvcNaluTypeParse(code) (SrsAvcNaluType)(code & 0x1F)
 std::string srs_avc_nalu2str(SrsAvcNaluType nalu_type);
 
 #ifdef SRS_H265
@@ -496,7 +504,18 @@ enum SrsHevcNaluType {
     SrsHevcNaluType_UNSPECIFIED_63,
     SrsHevcNaluType_INVALID,
 };
+// @see https://datatracker.ietf.org/doc/html/rfc7798#section-1.1.4
 #define SrsHevcNaluTypeParse(code) (SrsHevcNaluType)((code & 0x7E) >> 1)
+
+/**
+ * @see Table 7-7 – Name association to slice_type
+ * @doc ITU-T-H.265-2021.pdf, page 116.
+ */
+enum SrsHevcSliceType {
+    SrsHevcSliceTypeB = 0,
+    SrsHevcSliceTypeP = 1,
+    SrsHevcSliceTypeI = 2,
+};
 
 struct SrsHevcNalData {
     uint16_t nal_unit_length;
@@ -1320,7 +1339,10 @@ public:
     virtual SrsVideoCodecConfig* vcodec();
 public:
     static srs_error_t parse_avc_nalu_type(const SrsSample* sample, SrsAvcNaluType& avc_nalu_type);
-    static srs_error_t parse_avc_b_frame(const SrsSample* sample, bool& is_b_frame);
+    static srs_error_t parse_avc_bframe(const SrsSample* sample, bool& is_b_frame);
+
+    static srs_error_t parse_hevc_nalu_type(const SrsSample* sample, SrsHevcNaluType& hevc_nalu_type);
+    static srs_error_t parse_hevc_bframe(const SrsSample* sample, SrsFormat* format, bool& is_b_frame);
 };
 
 /**

--- a/trunk/src/kernel/srs_kernel_error.hpp
+++ b/trunk/src/kernel/srs_kernel_error.hpp
@@ -279,7 +279,7 @@
     XX(ERROR_HEVC_DECODE_ERROR             , 3099, "HevcDecode", "HEVC decode av stream failed")  \
     XX(ERROR_MP4_HVCC_CHANGE               , 3100, "Mp4HvcCChange", "MP4 does not support video HvcC change") \
     XX(ERROR_HEVC_API_NO_PREFIXED          , 3101, "HevcAnnexbPrefix", "No annexb prefix for HEVC decoder") \
-    XX(ERROR_AVC_NALU_EMPTY                , 3102, "AvcNaluEmpty", "AVC NALU is empty")
+    XX(ERROR_NALU_EMPTY                    , 3102, "NaluEmpty", "NALU is empty")
 
 /**************************************************/
 /* HTTP/StreamConverter protocol error. */

--- a/trunk/src/utest/srs_utest_rtc.cpp
+++ b/trunk/src/utest/srs_utest_rtc.cpp
@@ -62,7 +62,7 @@ VOID TEST(KernelRTCTest, RtpSTAPPayloadException)
     SrsAvcNaluType nalu_type = SrsAvcNaluTypeReserved;
     // Try to parse the NALU type for video decoder.
     if (!buf.empty()) {
-        nalu_type = SrsAvcNaluType((uint8_t)(buf.head()[0] & kNalTypeMask));
+        nalu_type = SrsAvcNaluTypeParse(buf.head()[0]);
     }
 
     EXPECT_TRUE(nalu_type == kStapA);


### PR DESCRIPTION
```bash
C:\Program Files\Google\Chrome\Application>"C:\Program Files\Google\Chrome\Application\chrome.exe" --enable-features=WebRtcAllowH265Receive --force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled

open -a "Google Chrome" --args --enable-features=WebRtcAllowH265Receive --force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled
```

> Note: The latest Chrome browser (version 136) fully enables this by
default, so there's no need to launch it with any extra parameters.

```bash
./objs/srs -c conf/rtmp2rtc.conf
```

```bash
ffmpeg -stream_loop -1 -re -i input.mp4 -c:v libx265 -preset fast -b:v 2000k -maxrate 2000k -bufsize 4000k -bf 0 -c:a aac -b:a 128k -ar 44100 -ac 2 -f flv rtmp://localhost/live/livestream
```

```bash
http://localhost:1985/rtc/v1/whep/?app=live&stream=livestream
```

![image](https://github.com/user-attachments/assets/bdbf4c67-b7e2-4dc6-92a1-93e2c78e00fe)

sendrecv offer
```bash
--enable-features=WebRtcAllowH265Send,PlatformHEVCEncoderSupport,WebRtcAllowH265Receive --force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled
```

sendonly offer
```bash
--enable-features=WebRtcAllowH265Send,PlatformHEVCEncoderSupport
```

recvonly offer
```bash
--enable-features=WebRtcAllowH265Receive --force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled
```

* Browser Test for supporting H265

https://webrtc.github.io/samples/src/content/peerconnection/change-codecs/

![image](https://github.com/user-attachments/assets/174476df-a7aa-4951-9880-56328ec75065)

* How to test Safari: https://github.com/ossrs/srs/pull/3441
* Debug in Safari

![image](https://github.com/user-attachments/assets/6cf94fca-e3ed-46d2-a102-a472f1699b4e)

---------





---------